### PR TITLE
Update crawler for Verdragenbank

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,6 @@
-# Dutch Disciplinary Law - Tuchtrecht Open Data
+# Dutch Treaty Database - Verdragenbank Open Data
 
-This project fetches daily data from the Tuchtrecht SRU endpoint provided by the Dutch government and:
-
-The Tuchtrecht (disciplinary law) corpus spans multiple professional fields:
-
-- **Accountants** – uitspraken van de Accountantskamer
-- **Advocaten** – uitspraken van de Raden van Discipline en het Hof van Discipline
-- **Diergeneeskundigen** – uitspraken van het Veterinair Tuchtcollege en het Veterinair Beroepscollege
-- **Gerechtsdeurwaarders** – uitspraken van de Kamer voor Gerechtsdeurwaarders
-- **Gezondheidszorg** – uitspraken van de Regionale Tuchtcolleges en het Centraal Tuchtcollege voor de Gezondheidszorg
-- **Notarissen** – uitspraken van de Kamers voor het notariaat
-- **Scheepvaart** – uitspraken van het Tuchtcollege voor de Scheepvaart
+This project fetches daily data from the Verdragenbank SRU endpoint provided by the Dutch government and stores them as JSONL shards. The same crawler structure that was used for the Tuchtrecht repository is reused here for the treaties collection.
 
 The crawler performs the following steps:
 
@@ -27,7 +17,7 @@ python3.11 -m pip install -r requirements.txt
 
 ## Daily Fetch Script
 
-Run manually (the crawler processes up to 10,000 records per run by default):
+Run manually (the crawler processes up to 250 records per run by default):
 
 ```bash
 python -m crawler.main
@@ -37,7 +27,7 @@ During execution the crawler prints each processed URL so progress is visible in
 the GitHub Actions log.
 
 Use `python -m crawler.main --reset` to ignore the last run timestamp and crawl the
-entire backlog. The `--max-records` option controls how many rulings are
+entire backlog. The `--max-records` option controls how many records are
 processed in a single run.
 
 Each run appends new JSONL files under `data/`. The timestamp of the last
@@ -55,7 +45,7 @@ Set the following environment variables before running the fetch script:
 * `HF_PRIVATE` – set to `true` to create a private dataset (optional)
 
 The dataset will be created under `HF_DATASET_REPO`, for example
-`vGassen/Dutch-Open-Data-Tuchrecht-Disciplinary-Court-Cases`.
+`vGassen/Dutch-Open-Data-Verdragenbank`.
 
 ## GitHub Actions
 

--- a/crawl.yml
+++ b/crawl.yml
@@ -1,7 +1,7 @@
 # .github/workflows/crawl.yml
-# This workflow automates the process of crawling the Tuchtrecht repository.
+# This workflow automates the process of crawling the Verdragenbank repository.
 
-name: Tuchtrecht Crawler
+name: Verdragenbank Crawler
 
 on:
   # Allows manual triggering of the workflow from the Actions tab in GitHub.
@@ -40,11 +40,11 @@ jobs:
 
       - name: Commit and push if it changed
         run: |
-          git config --global user.name "Tuchtrecht Crawler Bot"
+          git config --global user.name "Verdragenbank Crawler Bot"
           git config --global user.email "crawler-bot@users.noreply.github.com"
           git add data/ .last_update
           # Commit only if there are changes
-          git diff --staged --quiet || git commit -m "Weekly Tuchtrecht data update"
+          git diff --staged --quiet || git commit -m "Weekly Verdragenbank data update"
           git push
 
       - name: Upload data to Hugging Face

--- a/crawler/main.py
+++ b/crawler/main.py
@@ -1,5 +1,5 @@
 # crawler/main.py
-# Main entry point for the Tuchtrecht crawler.
+# Main entry point for the Verdragenbank crawler.
 
 import os
 import sys
@@ -19,9 +19,9 @@ from crawler.scrubber import scrub_text
 
 DATA_DIR = "data"
 LAST_UPDATE_FILE = ".last_update"
-BASE_QUERY = "c.product-area==tuchtrecht"
+BASE_QUERY = "c.product-area==verdragenbank"
 RECORDS_PER_SHARD = 1000
-DEFAULT_MAX_RECORDS = 10000
+DEFAULT_MAX_RECORDS = 250
 
 
 def get_last_run_date():
@@ -40,7 +40,7 @@ def save_last_run_date():
 
 def parse_args() -> argparse.Namespace:
     """Parse command line arguments."""
-    parser = argparse.ArgumentParser(description="Run the Tuchtrecht crawler")
+    parser = argparse.ArgumentParser(description="Run the Verdragenbank crawler")
     parser.add_argument(
         "--reset",
         action="store_true",
@@ -80,7 +80,7 @@ def main() -> None:
 
     # Find the latest shard index to append to it.
     existing_shards = [
-        f for f in os.listdir(DATA_DIR) if f.startswith("tuchtrecht_shard_")
+        f for f in os.listdir(DATA_DIR) if f.startswith("verdragenbank_shard_")
     ]
     if existing_shards:
         shard_index = max(
@@ -88,14 +88,14 @@ def main() -> None:
         )
         # Check if the latest shard is full
         with jsonlines.open(
-            os.path.join(DATA_DIR, f"tuchtrecht_shard_{shard_index:03d}.jsonl")
+            os.path.join(DATA_DIR, f"verdragenbank_shard_{shard_index:03d}.jsonl")
         ) as reader:
             records_in_current_shard = sum(1 for _ in reader)
         if records_in_current_shard >= RECORDS_PER_SHARD:
             shard_index += 1
             records_in_current_shard = 0
 
-    output_file = os.path.join(DATA_DIR, f"tuchtrecht_shard_{shard_index:03d}.jsonl")
+    output_file = os.path.join(DATA_DIR, f"verdragenbank_shard_{shard_index:03d}.jsonl")
     writer = jsonlines.open(output_file, mode="a")
 
     processed_count = 0
@@ -118,7 +118,7 @@ def main() -> None:
                 shard_index += 1
                 records_in_current_shard = 0
                 output_file = os.path.join(
-                    DATA_DIR, f"tuchtrecht_shard_{shard_index:03d}.jsonl"
+                    DATA_DIR, f"verdragenbank_shard_{shard_index:03d}.jsonl"
                 )
                 writer = jsonlines.open(output_file, mode="w")
 

--- a/crawler/parser.py
+++ b/crawler/parser.py
@@ -79,7 +79,7 @@ def parse_record(record: Dict[str, Any]) -> Optional[Dict[str, str]]:
         return {
             "URL": target_url,
             "Content": content,
-            "Source": "Tuchtrecht"
+            "Source": "Verdragenbank"
         }
     except Exception as e:
         print(f"Error parsing record: {e}")


### PR DESCRIPTION
## Summary
- update README for Verdragenbank crawler
- adjust workflow and code for Verdragenbank repository
- limit crawler to 250 records per run

## Testing
- `python -m py_compile crawler/main.py crawler/parser.py crawler/sru_client.py crawler/scrubber.py crawler/utils.py`
- `python -m crawler.main --max-records 1` *(fails: ModuleNotFoundError: No module named 'jsonlines')*

------
https://chatgpt.com/codex/tasks/task_e_6863924c4cec832988df7ffae1d3a97c