### PR TITLE
Fix SRU namespace parsing

### DIFF
--- a/crawler/parser.py
+++ b/crawler/parser.py
@@ -45,7 +45,7 @@ def parse_record(record: Dict[str, Any]) -> Optional[Dict[str, str]]:
         A dictionary with "URL", "Content", and "Source", or None if parsing fails.
     """
     try:
-        record_data = record.get('sru:recordData', {}).get('gzd:gzd', {})
+        record_data = record.get('srw:recordData', {}).get('gzd:gzd', {})
         enriched_data = record_data.get('gzd:enrichedData', {})
         
         # Prefer XML URL for full text extraction

--- a/crawler/sru_client.py
+++ b/crawler/sru_client.py
@@ -45,9 +45,9 @@ def get_records(query: str, start_date: str = None) -> Iterator[Dict[str, Any]]:
             
             import xmltodict
             data = xmltodict.parse(response.content)
-            
-            search_retrieve_response = data.get('sru:searchRetrieveResponse', {})
-            records = search_retrieve_response.get('sru:records', {}).get('sru:record', [])
+
+            search_retrieve_response = data.get('srw:searchRetrieveResponse', {})
+            records = search_retrieve_response.get('srw:records', {}).get('srw:record', [])
 
             if not records:
                 break


### PR DESCRIPTION
## Summary
- fix SRU namespace handling when parsing searchRetrieveResponse

## Testing
- `python -m py_compile crawler/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6863974729d48329bf3648b7364d94a3