### PR TITLE
Fix SRU endpoint for Verdragenbank crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dutch Treaty Database - Verdragenbank Open Data
 
-This project fetches daily data from the Verdragenbank SRU endpoint provided by the Dutch government and stores them as JSONL shards. The same crawler structure that was used for the Tuchtrecht repository is reused here for the treaties collection.
+This project fetches daily data from the Verdragenbank SRU endpoint provided by the Dutch government and stores them as JSONL shards. The crawler accesses the SRU service at `https://repository.overheid.nl/frbr/vd/sru`. The same crawler structure that was used for the Tuchtrecht repository is reused here for the treaties collection.
 
 The crawler performs the following steps:
 

--- a/crawler/sru_client.py
+++ b/crawler/sru_client.py
@@ -9,7 +9,9 @@ from .utils import get_session
 
 _SESSION = get_session()
 
-BASE_URL = "https://repository.overheid.nl/sru"
+# The Verdragenbank dataset is served under the "vd" FRBR collection.
+# Point the SRU client directly to that endpoint.
+BASE_URL = "https://repository.overheid.nl/frbr/vd/sru"
 PAGE_SIZE = 100 # As per SRU documentation, max is 1000, but we'll use a smaller size
 
 def get_records(query: str, start_date: str = None) -> Iterator[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- document exact SRU endpoint in README
- update `crawler/sru_client.py` to query `frbr/vd/sru`

## Testing
- `python -m py_compile crawler/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6863bf93c6948329bc1f7bc3a6aea854