### PR TITLE
Fix SRU endpoint path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dutch Treaty Database - Verdragenbank Open Data
 
-This project fetches daily data from the Verdragenbank SRU endpoint provided by the Dutch government and stores them as JSONL shards. The crawler accesses the SRU service at `https://repository.overheid.nl/frbr/vd/sru`. The same crawler structure that was used for the Tuchtrecht repository is reused here for the treaties collection.
+This project fetches daily data from the Verdragenbank SRU endpoint provided by the Dutch government and stores them as JSONL shards. The crawler accesses the SRU service at `https://repository.overheid.nl/sru`. The Verdragenbank data is retrieved by querying `c.product-area==vd`. The same crawler structure that was used for the Tuchtrecht repository is reused here for the treaties collection.
 
 The crawler performs the following steps:
 

--- a/crawler/main.py
+++ b/crawler/main.py
@@ -19,7 +19,7 @@ from crawler.scrubber import scrub_text
 
 DATA_DIR = "data"
 LAST_UPDATE_FILE = ".last_update"
-BASE_QUERY = "c.product-area==verdragenbank"
+BASE_QUERY = "c.product-area==vd"
 RECORDS_PER_SHARD = 1000
 DEFAULT_MAX_RECORDS = 250
 

--- a/crawler/sru_client.py
+++ b/crawler/sru_client.py
@@ -9,9 +9,10 @@ from .utils import get_session
 
 _SESSION = get_session()
 
-# The Verdragenbank dataset is served under the "vd" FRBR collection.
-# Point the SRU client directly to that endpoint.
-BASE_URL = "https://repository.overheid.nl/frbr/vd/"
+# The Verdragenbank dataset is served under the `vd` product area. The SRU
+# service itself is available at `https://repository.overheid.nl/sru`. Specifying
+# the product area in the query ensures the correct collection is returned.
+BASE_URL = "https://repository.overheid.nl/sru"
 PAGE_SIZE = 100 # As per SRU documentation, max is 1000, but we'll use a smaller size
 
 def get_records(query: str, start_date: str = None) -> Iterator[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- document SRU endpoint `https://repository.overheid.nl/sru`
- query the `vd` collection with `c.product-area==vd`
- update crawler configuration accordingly

## Testing
- `python -m pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `python -m crawler.main --max-records 1` *(fails: ModuleNotFoundError: no module named 'jsonlines')*


------
https://chatgpt.com/codex/tasks/task_e_6863c59f35fc8329ac5315169dd6e92d